### PR TITLE
fix: patch base-image vulnerabilities; correct multi-arch; safer tags + CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep the base image and GitHub Actions up to date automatically.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Dockerfile base image (alpine)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,10 @@ on:
     inputs:
       version:
         required: true
+      rebuild_exact:
+        description: "Force-republish the exact vX.Y.Z tag on the current patched base (security refresh of a recent release)"
+        required: false
+        default: ""
   push:
     branches:
       - main
@@ -13,6 +17,10 @@ on:
       - main
   schedule:
     - cron: '0 0 * * *'
+
+# `release` creates a GitHub release via GITHUB_TOKEN; Docker Hub auth uses secrets.
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -54,6 +62,7 @@ jobs:
         env:
           GITHUB_EVENT: ${{ github.event_name }}
           SET_VERSION: ${{ inputs.version }}
+          REBUILD_EXACT: ${{ inputs.rebuild_exact }}
 
       - name: build
         uses: docker/bake-action@v6

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,14 +18,17 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-# `release` creates a GitHub release via GITHUB_TOKEN; Docker Hub auth uses secrets.
+# Least privilege by default; only the release job is granted contents: write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    outputs:
+      gh_version: ${{ steps.tags.outputs.gh_version }}
+      skip: ${{ steps.tags.outputs.skip }}
     steps:
       - uses: actions/checkout@v4
 
@@ -65,6 +68,7 @@ jobs:
           REBUILD_EXACT: ${{ inputs.rebuild_exact }}
 
       - name: build
+        if: steps.tags.outputs.skip != 'true'
         uses: docker/bake-action@v6
         with:
           source: .
@@ -79,9 +83,16 @@ jobs:
           GH_VERSION: ${{ steps.tags.outputs.gh_version }}
           DOCKER_META_VERSION: ${{ steps.meta.outputs.version }}
 
-      - name: release
-        run: ./hooks/scripts/release
-        if: github.event_name != 'pull_request'
+  release:
+    name: release
+    needs: build
+    if: github.event_name != 'pull_request' && needs.build.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./hooks/scripts/release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_VERSION: ${{ steps.tags.outputs.gh_version }}
+          GH_VERSION: ${{ needs.build.outputs.gh_version }}

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,21 @@
+name: Hadolint
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: error

--- a/.github/workflows/refresh-recent-tags.yml
+++ b/.github/workflows/refresh-recent-tags.yml
@@ -1,0 +1,93 @@
+name: Refresh recent tags
+
+# Security refresh: rebuild the most recent few exact `vX.Y.Z` tags on the current
+# (patched) base, so consumers pinned to a recent version pick up base-image fixes
+# without changing their pin. Older exact tags stay frozen. This runs the build
+# directly (matrix over versions) rather than dispatching "Build and Release",
+# because workflow_dispatch from GITHUB_TOKEN would not trigger a new run.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'   # weekly, Monday 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      count:
+        description: "How many of the most recent releases to refresh"
+        required: false
+        default: "3"
+
+permissions:
+  contents: read
+
+jobs:
+  versions:
+    name: compute recent versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
+    steps:
+      - id: list
+        env:
+          COUNT: ${{ github.event.inputs.count || '3' }}
+        run: |
+          # Sanitize the input to digits only so it can't inject into the jq slice.
+          n=$(printf '%s' "$COUNT" | tr -cd '0-9')
+          [ -n "$n" ] || n=3
+          matrix=$(curl -s 'https://api.github.com/repos/cli/cli/releases' \
+            | jq -c --argjson n "$n" '[ .[] | select(.prerelease == false and .draft == false) | .tag_name | sub("^v"; "") ][0:$n]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  refresh:
+    name: refresh v${{ matrix.version }}
+    needs: versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.versions.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ github.repository }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # REBUILD_EXACT forces the existing exact tag to be republished on the patched
+      # base; for the newest release this also refreshes the rolling tags.
+      - run: ./hooks/scripts/set_tags
+        id: tags
+        env:
+          GITHUB_EVENT: ${{ github.event_name }}
+          SET_VERSION: ${{ matrix.version }}
+          REBUILD_EXACT: "1"
+
+      - name: build
+        uses: docker/bake-action@v6
+        with:
+          source: .
+          files: |
+            ./docker-bake.hcl
+            ./docker-bake.ci.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: default
+          push: true
+          pull: true
+        env:
+          GH_VERSION: ${{ steps.tags.outputs.gh_version }}
+          DOCKER_META_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/refresh-recent-tags.yml
+++ b/.github/workflows/refresh-recent-tags.yml
@@ -29,11 +29,19 @@ jobs:
       - id: list
         env:
           COUNT: ${{ github.event.inputs.count || '3' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Sanitize the input to digits only so it can't inject into the jq slice.
           n=$(printf '%s' "$COUNT" | tr -cd '0-9')
           [ -n "$n" ] || n=3
-          matrix=$(curl -s 'https://api.github.com/repos/cli/cli/releases' \
+          # Fail fast on HTTP errors / rate limiting instead of feeding bad JSON to
+          # fromJson; authenticate to get the higher API rate limit.
+          releases=$(curl -fsS --retry 3 \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/cli/cli/releases) \
+            || { echo "Failed to fetch cli/cli releases" >&2; exit 1; }
+          matrix=$(printf '%s' "$releases" \
             | jq -c --argjson n "$n" '[ .[] | select(.prerelease == false and .draft == false) | .tag_name | sub("^v"; "") ][0:$n]')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -20,7 +20,7 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         with:
           fail_on_error: true
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ github.token }}
           reporter: github-pr-review
           path: "./hooks"
           pattern: "*"

--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -1,0 +1,26 @@
+name: Shell Check
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          fail_on_error: true
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          path: "./hooks"
+          pattern: "*"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,46 @@
+name: Trivy vulnerability scan
+
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: trivy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t gh-scan:${{ github.sha }} .
+
+      # Informational: surface ALL fixable HIGH/CRITICAL findings (including the
+      # bundled gh Go binary) without failing.
+      - name: Trivy report (all package types)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: gh-scan:${{ github.sha }}
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '0'
+
+      # Gate: fail only on OS-package vulnerabilities -- what this image controls
+      # (the Alpine base + `apk upgrade`). CVEs inside the upstream gh binary can't
+      # be fixed here; they're resolved by bumping gh (handled by the CI version fetch).
+      - name: Trivy gate (OS packages only)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: gh-scan:${{ github.sha }}
+          format: table
+          vuln-type: os
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,5 @@
+# The image runs `apk upgrade` and installs unpinned packages on purpose, so it
+# always pulls the latest security patches. That is fundamentally incompatible
+# with pinning apk package versions, so ignore the version-pinning rule.
+ignored:
+  - DL3018  # Pin versions in apk add

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN case "${TARGETPLATFORM:-linux/amd64}" in \
     RELEASE_LOCATION="${GH_VERSION}_${GH_ARCH}" && \
     apk upgrade --no-cache && \
     apk add --no-cache wget rsync && \
-    wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${RELEASE_LOCATION}.tar.gz && \
-    tar -zxvf gh_${RELEASE_LOCATION}.tar.gz && \
-    chmod +x gh_${RELEASE_LOCATION}/bin/gh && \
-    rsync -az --remove-source-files gh_${RELEASE_LOCATION}/bin/ /usr/bin
+    wget -q "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${RELEASE_LOCATION}.tar.gz" && \
+    tar -zxvf "gh_${RELEASE_LOCATION}.tar.gz" && \
+    chmod +x "gh_${RELEASE_LOCATION}/bin/gh" && \
+    rsync -az --remove-source-files "gh_${RELEASE_LOCATION}/bin/" /usr/bin
 
 FROM alpine:3.24.1 as gh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,32 @@
 #syntax=docker/dockerfile:1.2
-FROM --platform=$BUILDPLATFORM alpine:3.21.3 as builder
+FROM --platform=$BUILDPLATFORM alpine:3.24.1 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG GH_VERSION=2.10.1
+ARG GH_VERSION=2.95.0
 
-RUN export RELEASE_LOCATION="${GH_VERSION}_$(echo "${BUILDPLATFORM//\//_}")" && \
+# Download the gh release built for the TARGET platform (not the build host), so
+# multi-arch images ship the correct binary. gh's asset names don't match Docker's
+# platform strings 1:1 (e.g. linux/arm64/v8 -> linux_arm64, and there is no armv7
+# build -- the armv6 binary runs on armv7), so map them explicitly.
+RUN case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/amd64")                  GH_ARCH="linux_amd64" ;; \
+      "linux/arm64" | "linux/arm64/v8") GH_ARCH="linux_arm64" ;; \
+      "linux/arm/v7" | "linux/arm/v6") GH_ARCH="linux_armv6" ;; \
+      "linux/386")                    GH_ARCH="linux_386" ;; \
+      *) echo "unsupported TARGETPLATFORM: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac && \
+    RELEASE_LOCATION="${GH_VERSION}_${GH_ARCH}" && \
+    apk upgrade --no-cache && \
     apk add --no-cache wget rsync && \
     wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${RELEASE_LOCATION}.tar.gz && \
     tar -zxvf gh_${RELEASE_LOCATION}.tar.gz && \
     chmod +x gh_${RELEASE_LOCATION}/bin/gh && \
     rsync -az --remove-source-files gh_${RELEASE_LOCATION}/bin/ /usr/bin
 
-FROM alpine:3.21.3 as gh
+FROM alpine:3.24.1 as gh
 
-RUN apk add --no-cache git libc6-compat
+RUN apk upgrade --no-cache && apk add --no-cache git libc6-compat
 COPY --from=builder /usr/bin/gh /usr/bin/
 
 VOLUME /gh

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ https://github.com/maniator/gh
 
 https://hub.docker.com/r/maniator/gh/tags/
 
+Tagging scheme:
+
+- `latest` — newest gh release on a current, security-patched base. Moves over time.
+- `v2`, `v2.95` (rolling major / major.minor) — newest patch of that line, rebuilt on a
+  patched base. Pin one of these if you want a stable gh line that still receives base-image
+  security updates.
+- `v2.95.0` (fully-qualified) — a fixed gh version. The most recent few releases are periodically
+  rebuilt on a patched base for security; older versions stay frozen exactly as first published
+  (so long-standing reproducible pins don't shift OS underneath them). If you always want the
+  newest patched build for a release line, pin a rolling tag (`v2.95` / `v2`) instead.
+
 ### Usage
 
 ```shell

--- a/downstream-usage-report.md
+++ b/downstream-usage-report.md
@@ -1,0 +1,88 @@
+# Downstream usage of `maniator/gh` — vulnerability exposure report
+
+Generated from a `gh search code "maniator/gh"` sweep of **public** GitHub repos (default branches
+only). GitHub's code-search API caps results (~100 per query / ~1000 total, rate-limited), so this
+is a **representative sample, not a complete census**. The image has ~624k Docker Hub pulls, so real
+usage is far larger than what is indexed here.
+
+## How exposure is fixed
+
+- **`:latest` / untagged consumers** → automatically protected once the patched `latest` is published
+  (Alpine `3.24.1` + `apk upgrade`). **No action required on their side.**
+- **Consumers pinning a recent `:vX.Y.Z` tag** → the most recent few releases are **rebuilt on the
+  patched base** (a deliberate, opt-in security refresh via `REBUILD_EXACT=1`, driven by
+  `hooks/scripts/rebuild_recent`). These tags are on Alpine 3.21, so the patch is a small, low-risk
+  bump and recent pins get fixed in place with no change on the consumer's side.
+- **Consumers pinning an OLD `:vX.Y.Z` tag** → we deliberately **leave these frozen**. Silently
+  rebuilding `v2.10.1` (Alpine 3.15) onto Alpine 3.24 is a major-OS jump that could break setups
+  pinned for reproducibility (newer musl/git, different package set). Instead we publish **opt-in
+  rolling tags** — `vMAJOR` / `vMAJOR.MINOR` (e.g. `v2`, `v2.95`) — that always point at the latest
+  patched build, so anyone who wants patches can switch their pin without us rewriting frozen history.
+
+> Note: we deliberately do **not** open PRs against third-party consumer repos — unsolicited mass PRs
+> are out of scope. Patching `latest`/rolling tags protects consumers without touching their code.
+
+## Consumers pinning OLD version tags (vulnerable until the tag is rebuilt)
+
+| Repo | Pinned tag |
+|------|-----------|
+| myspotontheweb/argocd-springboot-demo2 | v2.29.0 |
+| Alexey-T/lexer_tests | v2.40.1 |
+| Sir-NoChill/pkl-rust | v2.40.1 |
+| gian-didom/pkl-lang-ssh | v2.40.1 |
+| kdeps/schema | v2.40.1 |
+| tenantcloud/laravel-better-cache | v2.48.0 |
+| tenantcloud/laravel-boolean-softdeletes | v2.48.0 |
+| tenantcloud/laravel-graphql-platform | v2.48.0 |
+| mock-server/mockserver-monorepo | v2.62.0 |
+| syncloud/image | v2.65.0 |
+| quartz-technology/dagger-agents | v2.68.1 |
+| aperture-sci/DevOps | v2.76.0 |
+| fx-integral/academia-archives | v2.79.0 |
+| tensorplex-labs/dojo | v2.79.0 |
+| PingCAP-QE/ci | v2.83.2 |
+| bccalegari/dev-link-iac | v2.83.2 |
+| britter/gh-get | v2.92.0 |
+
+**Distinct old tags to rebuild on the patched base:**
+`v2.29.0 v2.40.1 v2.48.0 v2.62.0 v2.65.0 v2.68.1 v2.76.0 v2.79.0 v2.83.2 v2.92.0`
+(plus `v2.10.1`, the prior Dockerfile default).
+
+## Tag pull-recency (Docker Hub `tag_last_pulled`)
+
+Docker Hub's public tags API exposes a `tag_last_pulled` timestamp per tag (but **not** a per-tag
+pull *count* — only the repo-wide total of ~624k). Pulling that data for the rebuild-candidate tags:
+
+| Tag | Last pulled | Last pushed | Note |
+|-----|-------------|-------------|------|
+| v2.10.1 | 2026-06-19 | 2022-10-28 | still pulled today, 3.5 yrs after push |
+| v2.29.0 | — | — | **not published to the registry** — downstream pin is already broken |
+| v2.40.1 | 2026-06-19 | 2024-01-08 | active |
+| v2.48.0 | 2026-06-19 | 2024-04-30 | most-recently-pulled tag in the whole repo |
+| v2.62.0 | 2026-06-19 | 2024-11-27 | active |
+| v2.65.0 | 2026-06-19 | 2025-01-29 | active |
+| v2.68.1 | 2026-06-19 | 2025-03-19 | active |
+| v2.76.0 | 2026-06-19 | 2025-07-23 | active |
+| v2.79.0 | 2026-06-19 | 2025-09-23 | active |
+| v2.83.2 | 2026-06-19 | 2026-01-14 | active |
+| v2.92.0 | 2026-06-19 | 2026-05-27 | active |
+
+**Finding:** across all 96 published tags, virtually every historical tag was pulled within the last
+day — old pins are genuinely live, so the exposure is real. The fix is tiered: the most recent few
+exact tags get an in-place **patched rebuild** (low-risk, they're on Alpine 3.21); the patched
+`latest`/`v2`/`v2.95` rolling lines move forward for everyone else; and old exact pins stay **frozen**
+as their authors intended. (Caveat: `tag_last_pulled` counts any pull — CI, scanners, registry
+mirrors, our own tests — so it proves "still in use" but can't rank tags by volume.)
+
+## Consumers on `:latest` or untagged (auto-fixed, no action needed)
+
+4min/resume · CircleCI-Public/circleci-server-monitoring-reference ·
+CircleCI-Public/container-runner-helm-chart · ClawGym/ClawGym-Agents · DursunKm/docker-dev-tools ·
+InnovatorLM/Innovator-VL · Jackie2049/prefix-0501 · JoyboySol/Megatron-LM · MansonBruv/capstone ·
+Miya-315/7608_LLM · NVIDIA/Megatron-LM · PingCAP-QE/ci · Sphere-AI-Lab/pion · aperture-sci/DevOps ·
+buegelbeatz/tsp-quantum · containifyci/engine-ci · dumasd/config-ops · dylanyunlon/Neuron_SP ·
+fhdsl/capstone-sandbox · geekittime/evoclaw · hotosm/docs ·
+kubiya-solutions-engineering/developer-onboarding · kubiya-solutions-engineering/hackathon-tools ·
+kubiyabot/community-tools · minvws/nl-rdo-woo-web · mock-server/mockserver-monorepo ·
+mohsen-deriv/action-create-pull-request-another-repo · shanearcaro/automatic-labeler ·
+shushuzn/workspace · zhejianglab/Gengram

--- a/hooks/scripts/rebuild_recent
+++ b/hooks/scripts/rebuild_recent
@@ -1,0 +1,23 @@
+#!/bin/sh -x
+#
+# Security refresh of the most recent N gh release tags: rebuild their exact
+# `vX.Y.Z` images on the current (patched) base, so consumers pinned to a recent
+# version pick up base-image fixes without changing their pin. Older exact tags
+# are intentionally left frozen (rebuilding e.g. v2.10.1's Alpine 3.15 onto a new
+# Alpine major risks breaking long-pinned, reproducibility-sensitive setups).
+#
+# Usage:   ./hooks/scripts/rebuild_recent [N]   (default N=3)
+# Requires: gh CLI authenticated with workflow-dispatch permission on maniator/gh.
+
+set -e
+
+N=${1:-3}
+
+gh api repos/cli/cli/releases --jq '.[] | select(.prerelease == false and .draft == false) | .tag_name' \
+  | head -n "$N" \
+  | sed 's/^v//' \
+  | while read -r v; do
+      echo "Dispatching patched rebuild of maniator/gh:v$v"
+      gh workflow run "Build and Release" -f version="$v" -f rebuild_exact=1
+      sleep 2
+    done

--- a/hooks/scripts/set_tags
+++ b/hooks/scripts/set_tags
@@ -4,6 +4,31 @@ VERSION=$(curl -s 'https://api.github.com/repos/cli/cli/releases' | jq -r '.[0].
 
 GH_VERSION=${SET_VERSION:-$VERSION}
 
+# The exact, fully-qualified `vX.Y.Z` tag is immutable by default: publish it only
+# the first time we build a given gh version. Once it exists on Docker Hub we don't
+# rebuild it, so a pin like `v2.95.0` stays byte-for-byte reproducible even though
+# the nightly job keeps refreshing the rolling tags on a freshly-patched base.
+#
+# Exception: a deliberate security refresh of recent releases. Set REBUILD_EXACT=1
+# (via workflow_dispatch) to force-republish an existing exact tag on the current
+# patched base -- used only for the most recent few releases; older tags stay frozen.
+EXACT_TAG="    \"maniator/gh:v${GH_VERSION}\","
+if [ -z "$REBUILD_EXACT" ] && curl -sfL -o /dev/null "https://hub.docker.com/v2/repositories/maniator/gh/tags/v${GH_VERSION}/"; then
+  echo "maniator/gh:v${GH_VERSION} already published -- leaving it immutable (set REBUILD_EXACT=1 to force a patched rebuild)"
+  EXACT_TAG=""
+fi
+
+# Rolling tags (`latest`, `vMAJOR`, `vMAJOR.MINOR`) always move to the newest gh
+# release on a freshly-patched base, giving version-conscious users an opt-in line
+# that keeps receiving base-image security patches. Only emitted when building the
+# newest release, so a `workflow_dispatch` of an older version never clobbers them.
+ROLLING_TAGS=""
+if [ "$GH_VERSION" = "$VERSION" ]; then
+  GH_MAJOR=$(echo "$GH_VERSION" | cut -d. -f1)
+  GH_MINOR=$(echo "$GH_VERSION" | cut -d. -f1,2)
+  ROLLING_TAGS=$(printf '    "maniator/gh:v%s",\n    "maniator/gh:v%s",\n    "maniator/gh:latest",' "$GH_MAJOR" "$GH_MINOR")
+fi
+
 cat <<EOF > docker-bake.ci.hcl
 variable "DOCKER_META_VERSION" { default="" }
 
@@ -14,10 +39,10 @@ group "default" {
 target "ci_build" {
   inherits = ["build", "docker-metadata-action"]
   tags = [
-    "maniator/gh:v${GH_VERSION}",
-    "maniator/gh:latest",
+${EXACT_TAG}
+${ROLLING_TAGS}
   ]
 }
 EOF
 
-echo "gh_version=${GH_VERSION}" >> $GITHUB_OUTPUT
+echo "gh_version=${GH_VERSION}" >> "$GITHUB_OUTPUT"

--- a/hooks/scripts/set_tags
+++ b/hooks/scripts/set_tags
@@ -1,8 +1,18 @@
 #!/bin/sh -x
 
-VERSION=$(curl -s 'https://api.github.com/repos/cli/cli/releases' | jq -r '.[0].tag_name' | sed -e 's/^v//')
+# Latest *stable* gh release (skip drafts/prereleases so rolling tags don't get
+# suppressed or moved onto a prerelease).
+VERSION=$(curl -s 'https://api.github.com/repos/cli/cli/releases' | jq -r '[ .[] | select(.prerelease == false and .draft == false) | .tag_name ][0]' | sed -e 's/^v//')
 
 GH_VERSION=${SET_VERSION:-$VERSION}
+
+# GH_VERSION is interpolated into the Docker Hub URL and the generated bake tags, so
+# reject anything that isn't a plain X.Y.Z before it can break the bake file or push
+# unexpected tags.
+if ! printf '%s' "$GH_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Refusing to build: GH_VERSION='$GH_VERSION' is not a valid X.Y.Z version" >&2
+  exit 1
+fi
 
 # The exact, fully-qualified `vX.Y.Z` tag is immutable by default: publish it only
 # the first time we build a given gh version. Once it exists on Docker Hub we don't

--- a/hooks/scripts/set_tags
+++ b/hooks/scripts/set_tags
@@ -46,3 +46,13 @@ ${ROLLING_TAGS}
 EOF
 
 echo "gh_version=${GH_VERSION}" >> "$GITHUB_OUTPUT"
+
+# Nothing to publish when the exact tag already exists (REBUILD_EXACT unset) and
+# this isn't the newest release (no rolling tags). Signal the workflow to skip the
+# build/release rather than producing an empty tag list and a no-op push.
+if [ -z "$EXACT_TAG" ] && [ -z "$ROLLING_TAGS" ]; then
+  echo "Nothing to publish: v${GH_VERSION} already exists and REBUILD_EXACT is unset -- skipping build."
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+else
+  echo "skip=false" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
## Why

`maniator/gh` (~624k pulls) ships on a pinned, increasingly stale Alpine base (what Snyk / Docker Scout flag), and along the way this surfaced a multi-arch binary bug. This patches the base, fixes the binary bug, gives version-pinning consumers a non-breaking path to security updates, and adds CI to catch regressions.

## What

**Base-image / CVE fixes** — apply to `latest` and all future builds, zero breakage:
- Alpine `3.21.3` → `3.24.1` in both stages + `apk upgrade --no-cache`
- Default `GH_VERSION` `2.10.1` → `2.95.0` (CI still fetches real latest via `set_tags`)

**Multi-arch correctness** (real bug; supersedes #42):
- Download the gh release for `TARGETPLATFORM`, not `BUILDPLATFORM` — arm64/arm images were shipping the **amd64** binary. gh asset names don't map 1:1 to Docker platforms (`linux/arm64/v8` → `linux_arm64`; no `armv7` build, `armv6` runs on armv7), so they're mapped explicitly. Verified with a `linux/amd64,linux/arm64,linux/arm/v7` buildx build.

**Tag strategy** — protect pinners without breaking reproducibility:
- Rolling `vMAJOR` / `vMAJOR.MINOR` (`v2`, `v2.95`) + `latest` move on the patched base, only when building the newest release.
- Exact `vX.Y.Z` tags are **immutable by default** (published once; nightly no longer republishes them).
- `REBUILD_EXACT=1` (workflow_dispatch input) force-refreshes recent exact tags on the patched base; `hooks/scripts/rebuild_recent` does the latest N=3. Older tags stay frozen.
- README documents the moving / rolling / immutable scheme.

**New PR-validation workflows** (parity with dind-buildx + vuln focus):
- Trivy image scan (PR + weekly), hadolint (+ `.hadolint.yaml`), shellcheck, dependabot (base image + Actions).

**Report**: `downstream-usage-report.md` — consumer exposure (`gh search code`) + Docker Hub `tag_last_pulled` analysis.

## Verification

- `docker build` → `gh version 2.95.0`; multi-arch buildx confirms each platform pulls its own `gh_2.95.0_linux_<arch>.tar.gz`.
- `set_tags` validated against the live registry: newest build emits rolling tags only (leaves `v2.95.0` untouched); a missing version emits its exact tag; `REBUILD_EXACT=1` forces it.
- `hadolint` + `shellcheck` run clean locally; all workflow YAML validated.

Addresses the Copilot + Codex review comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)