### PR TITLE
ci: bump GitHub Actions to latest majors (consolidates #44–#48)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,7 @@ jobs:
       gh_version: ${{ steps.tags.outputs.gh_version }}
       skip: ${{ steps.tags.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
@@ -45,16 +45,13 @@ jobs:
             type=sha
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          install: true
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -69,7 +66,7 @@ jobs:
 
       - name: build
         if: steps.tags.outputs.skip != 'true'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
           source: .
           files: |
@@ -91,7 +88,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: ./hooks/scripts/release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -14,7 +14,7 @@ jobs:
     name: hadolint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: Dockerfile

--- a/.github/workflows/refresh-recent-tags.yml
+++ b/.github/workflows/refresh-recent-tags.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         version: ${{ fromJson(needs.versions.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
@@ -63,15 +63,13 @@ jobs:
           images: ${{ github.repository }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          install: true
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -86,7 +84,7 @@ jobs:
           REBUILD_EXACT: "1"
 
       - name: build
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
           source: .
           files: |

--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -15,7 +15,7 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,7 +16,7 @@ jobs:
     name: trivy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build image
         run: docker build -t gh-scan:${{ github.sha }} .


### PR DESCRIPTION
Reviews and consolidates the five open dependabot action bumps into one commit.

## Validity review

| Action | Bump | Verdict |
|--------|------|---------|
| actions/checkout | v4 → v7 | ✅ bare usage; only change is Node 24 runtime (fine on ubuntu-latest) |
| docker/setup-qemu-action | v3 → v4 | ✅ bare usage |
| docker/login-action | v3 → v4 | ✅ username/password inputs unchanged |
| docker/setup-buildx-action | v3 → v4 | ⚠️ **`install` input removed in v4** — dropped it (we don't need it; bake-action drives buildx directly). Also removed the unused `id: buildx`. |
| docker/bake-action | v6 → v7 | ✅ `source`/`files`/`targets`/`push`/`pull` all still present; we use `source:` (not the removed `workdir`); deprecated envs/subactions we don't use |

The raw dependabot PR #47 would have bumped setup-buildx to v4 but left the now-invalid `install: true` (a workflow warning) — handled here.

## Supersedes
#44, #45, #46, #47, #48 — dependabot will auto-close them once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)